### PR TITLE
Bump to SDK 27 and Gradle 4.4

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,4 @@
-version = '1.3.3'
+version = '1.3.4'
 
 apply plugin: 'com.github.ben-manes.versions'
 

--- a/build.gradle
+++ b/build.gradle
@@ -6,9 +6,9 @@ buildscript {
     ext.kotlin_version = '1.2.21'
     ext.versions = [
         'minSdk': 14,
-        'compileSdk': 26,
-        'buildTools': '26.0.2',
-        'supportLibrary': '26.0.2',
+        'compileSdk': 27,
+        'buildTools': '27.0.2',
+        'supportLibrary': '27.1.0',
         'androidPlugin': '3.0.1'
     ]
 

--- a/build.gradle
+++ b/build.gradle
@@ -23,8 +23,8 @@ buildscript {
             'compat': "com.android.support:support-compat:${versions.supportLibrary}",
             'design': "com.android.support:design:${versions.supportLibrary}"
         ],
-        javapoet: 'com.squareup:javapoet:1.9.0',
-        autoService: 'com.google.auto.service:auto-service:1.0-rc3',
+        javapoet: 'com.squareup:javapoet:1.10.0',
+        autoService: 'com.google.auto.service:auto-service:1.0-rc4',
         junit: 'junit:junit:4.12'
     ]
 
@@ -38,7 +38,7 @@ buildscript {
 
     dependencies {
         classpath deps.android.gradlePlugin
-        classpath 'com.github.ben-manes:gradle-versions-plugin:0.15.0'
+        classpath 'com.github.ben-manes:gradle-versions-plugin:0.17.0'
         classpath 'com.dicedmelon.gradle:jacoco-android:0.1.2'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-all.zip

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -6,8 +6,8 @@ android {
     buildToolsVersion versions.buildTools
 
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_1_7
-        targetCompatibility = JavaVersion.VERSION_1_7
+        sourceCompatibility = JavaVersion.VERSION_1_8
+        targetCompatibility = JavaVersion.VERSION_1_8
     }
 
     defaultConfig {


### PR DESCRIPTION
on my project (target api 27 and latest dependencies version) I wasn't able to get the annotations to be compiled by my app. I updated the dependencies in the project and I now can import them.

When I build though I'm getting the following errors:
```
Error:java.lang.IllegalAccessException: no such method: convalida.compiler.ConvalidaProcessor.lambda$parseValidateOnClick$0(Element)boolean/invokeStatic
Error:java.lang.NoClassDefFoundError: com/sun/tools/javac/tree/JCTree$Visitor
Error:java.lang.ClassNotFoundException: Class com.sun.tools.javac.tree.JCTree$Visitor not found
```